### PR TITLE
Remove the networking module

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,6 @@ extern crate rand;
 pub mod analysis;
 pub mod error;
 pub mod file;
-pub mod networking;
 pub mod processing;
 
 use std::fmt;


### PR DESCRIPTION
This module is useless for now.

Closes https://github.com/Kagamihime/rlife/issues/1