### PR TITLE
TravisCI: Change the default script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,6 @@ matrix:
     allow_failures:
         - rust: nightly
     fast_finish: true
+
+script:
+    - cargo build


### PR DESCRIPTION
This changes the script used by Travis CI so that it doesn't try to
test the library.

Fixes https://github.com/Kagamihime/rlife/issues/17